### PR TITLE
core-963 only override fielderrors, else return standard err

### DIFF
--- a/grpc/interceptor/logger.go
+++ b/grpc/interceptor/logger.go
@@ -33,12 +33,13 @@ func Logger(l *logrus.Logger) grpc.UnaryServerInterceptor {
 				entry.WithError(ferr).WithFields(*fields).WithField(
 					"core.duration", float64(time.Since(start)) / float64(time.Millisecond),
 				).Error("rpc endpoint " + name + " failed")
+				return nil, ErrGrpcInternalError
 			} else {
 				entry.WithError(err).WithField(
 					"core.duration", float64(time.Since(start)) / float64(time.Millisecond),
 				).Error("rpc endpoint " + name + " failed")
+				return nil, err
 			}
-			return nil, ErrGrpcInternalError
 		}
 
 		entry.WithFields(logrus.Fields{

--- a/grpc/interceptor/logger.go
+++ b/grpc/interceptor/logger.go
@@ -34,12 +34,12 @@ func Logger(l *logrus.Logger) grpc.UnaryServerInterceptor {
 					"core.duration", float64(time.Since(start)) / float64(time.Millisecond),
 				).Error("rpc endpoint " + name + " failed")
 				return nil, ErrGrpcInternalError
-			} else {
-				entry.WithError(err).WithField(
-					"core.duration", float64(time.Since(start)) / float64(time.Millisecond),
-				).Error("rpc endpoint " + name + " failed")
-				return nil, err
 			}
+
+			entry.WithError(err).WithField(
+				"core.duration", float64(time.Since(start)) / float64(time.Millisecond),
+			).Error("rpc endpoint " + name + " failed")
+			return nil, err
 		}
 
 		entry.WithFields(logrus.Fields{


### PR DESCRIPTION
if a fielderror is returned (a custom error type that allows us to pass fields for logging, used in accounts service and available for other services) then return a generic error and log the given fields

if a standard error is returned, e.g. a GRPC standard code error, then log only the essentials and return the standard error as is