### PR TITLE
Remove processing logline as its not really needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+!vendor/vendor.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: go
 go:
 - 1.8.x
 before_install:
-- govendor fetch
+- go get -u github.com/kardianos/govendor
+- go get ./...
+- govendor sync
 script:
 - go test -v ./...
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,8 @@ language: go
 go:
 - 1.8.x
 before_install:
-- go get golang.org/x/net/context
-- go get github.com/sirupsen/logrus
-- go get google.golang.org/grpc
-- go get github.com/stretchr/testify/mock
-- go get github.com/davecgh/go-spew/spew
-- go get github.com/pmezard/go-difflib/difflib
-- go get github.com/stretchr/objx
-- go get github.com/stretchr/testify/assert
-- go get github.com/stretchr/testify/require
-- go get github.com/satori/go.uuid
+- go get ./...
+- govendor sync
 script:
 - go test -v ./...
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: go
 go:
 - 1.8.x
 before_install:
-- go get ./...
-- govendor sync
+- govendor fetch
 script:
 - go test -v ./...
 notifications:

--- a/grpc/interceptor/logger.go
+++ b/grpc/interceptor/logger.go
@@ -50,6 +50,11 @@ func Logger(l *logrus.Logger) grpc.UnaryServerInterceptor {
 }
 
 func addLoggerToContext(ctx context.Context, l *logrus.Logger) context.Context {
-	entry := l.WithField("request_id", uuid.NewV4().String())
+	id, err := uuid.NewV4()
+	if err != nil {
+		logrus.WithError(err).Fatal("could not generate request id")
+	}
+
+	entry := l.WithField("request_id", id.String())
 	return logger.SetEntry(ctx, entry)
 }

--- a/grpc/interceptor/logger_test.go
+++ b/grpc/interceptor/logger_test.go
@@ -43,19 +43,15 @@ func TestLoggerInterceptor(t *testing.T) {
 	middleware(ctx, nil, info, final)
 
 	decoder := json.NewDecoder(buf)
+
 	var firstLine logLine
 	require.NoError(t, decoder.Decode(&firstLine))
-	assert.Equal(t, "processing rpc", firstLine.Msg)
+	assert.Equal(t, "from handler", firstLine.Msg)
 	assert.NotEmpty(t, firstLine.RequestID)
 
 	var secondLine logLine
 	require.NoError(t, decoder.Decode(&secondLine))
-	assert.Equal(t, "from handler", secondLine.Msg)
+	assert.Equal(t, "finished rpc", secondLine.Msg)
 	assert.NotEmpty(t, secondLine.RequestID)
-
-	var thirdLine logLine
-	require.NoError(t, decoder.Decode(&thirdLine))
-	assert.Equal(t, "finished rpc", thirdLine.Msg)
-	assert.NotEmpty(t, thirdLine.RequestID)
-	assert.NotEmpty(t, thirdLine.Duration)
+	assert.NotEmpty(t, secondLine.Duration)
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,0 +1,321 @@
+{
+	"comment": "",
+	"ignore": "test",
+	"package": [
+		{
+			"checksumSHA1": "tUZmNMotCGdra/Ep3fB3H1nc4Uw=",
+			"path": "github.com/armon/go-metrics",
+			"revision": "7aa49fde808223f8dadfdbfd3a20ff6c19e5f9ec",
+			"revisionTime": "2017-11-17T18:41:20Z"
+		},
+		{
+			"checksumSHA1": "OFu4xJEIjiI8Suu+j/gabfp+y6Q=",
+			"origin": "github.com/stretchr/testify/vendor/github.com/davecgh/go-spew/spew",
+			"path": "github.com/davecgh/go-spew/spew",
+			"revision": "2aa2c176b9dab406a6970f6a55f513e8a8c8b18f",
+			"revisionTime": "2017-08-14T20:04:35Z"
+		},
+		{
+			"checksumSHA1": "yqF125xVSkmfLpIVGrLlfE05IUk=",
+			"path": "github.com/golang/protobuf/proto",
+			"revision": "1e59b77b52bf8e4b449a57e6f79f21226d571845",
+			"revisionTime": "2017-11-13T18:07:20Z"
+		},
+		{
+			"checksumSHA1": "VfkiItDBFFkZluaAMAzJipDXNBY=",
+			"path": "github.com/golang/protobuf/ptypes",
+			"revision": "1e59b77b52bf8e4b449a57e6f79f21226d571845",
+			"revisionTime": "2017-11-13T18:07:20Z"
+		},
+		{
+			"checksumSHA1": "UB9scpDxeFjQe5tEthuR4zCLRu4=",
+			"path": "github.com/golang/protobuf/ptypes/any",
+			"revision": "1e59b77b52bf8e4b449a57e6f79f21226d571845",
+			"revisionTime": "2017-11-13T18:07:20Z"
+		},
+		{
+			"checksumSHA1": "hUjAj0dheFVDl84BAnSWj9qy2iY=",
+			"path": "github.com/golang/protobuf/ptypes/duration",
+			"revision": "1e59b77b52bf8e4b449a57e6f79f21226d571845",
+			"revisionTime": "2017-11-13T18:07:20Z"
+		},
+		{
+			"checksumSHA1": "O2ItP5rmfrgxPufhjJXbFlXuyL8=",
+			"path": "github.com/golang/protobuf/ptypes/timestamp",
+			"revision": "1e59b77b52bf8e4b449a57e6f79f21226d571845",
+			"revisionTime": "2017-11-13T18:07:20Z"
+		},
+		{
+			"checksumSHA1": "Cas2nprG6pWzf05A2F/OlnjUu2Y=",
+			"path": "github.com/hashicorp/go-immutable-radix",
+			"revision": "8aac2701530899b64bdea735a1de8da899815220",
+			"revisionTime": "2017-07-25T22:12:15Z"
+		},
+		{
+			"checksumSHA1": "9hffs0bAIU6CquiRhKQdzjHnKt0=",
+			"path": "github.com/hashicorp/golang-lru/simplelru",
+			"revision": "0a025b7e63adc15a622f29b0b2c4c3848243bbf6",
+			"revisionTime": "2016-08-13T22:13:03Z"
+		},
+		{
+			"checksumSHA1": "zKKp5SZ3d3ycKe4EKMNT0BqAWBw=",
+			"origin": "github.com/stretchr/testify/vendor/github.com/pmezard/go-difflib/difflib",
+			"path": "github.com/pmezard/go-difflib/difflib",
+			"revision": "2aa2c176b9dab406a6970f6a55f513e8a8c8b18f",
+			"revisionTime": "2017-08-14T20:04:35Z"
+		},
+		{
+			"checksumSHA1": "zmC8/3V4ls53DJlNTKDZwPSC/dA=",
+			"path": "github.com/satori/go.uuid",
+			"revision": "5bf94b69c6b68ee1b541973bb8e1144db23a194b",
+			"revisionTime": "2017-03-21T23:07:31Z"
+		},
+		{
+			"checksumSHA1": "ySaT8G3I3y4MmnoXOYAAX0rC+p8=",
+			"path": "github.com/sirupsen/logrus",
+			"revision": "d682213848ed68c0a260ca37d6dd5ace8423f5ba",
+			"revisionTime": "2017-12-05T20:32:29Z"
+		},
+		{
+			"checksumSHA1": "mGbTYZ8dHVTiPTTJu3ktp+84pPI=",
+			"path": "github.com/stretchr/testify/assert",
+			"revision": "2aa2c176b9dab406a6970f6a55f513e8a8c8b18f",
+			"revisionTime": "2017-08-14T20:04:35Z"
+		},
+		{
+			"checksumSHA1": "7vs6dSc1PPGBKyzb/SCIyeMJPLQ=",
+			"path": "github.com/stretchr/testify/require",
+			"revision": "2aa2c176b9dab406a6970f6a55f513e8a8c8b18f",
+			"revisionTime": "2017-08-14T20:04:35Z"
+		},
+		{
+			"checksumSHA1": "nqWNlnMmVpt628zzvyo6Yv2CX5Q=",
+			"path": "golang.org/x/crypto/ssh/terminal",
+			"revision": "bd6f299fb381e4c3393d1c4b1f0b94f5e77650c8",
+			"revisionTime": "2017-10-31T10:16:35Z"
+		},
+		{
+			"checksumSHA1": "GtamqiJoL7PGHsN454AoffBFMa8=",
+			"path": "golang.org/x/net/context",
+			"revision": "d866cfc389cec985d6fda2859936a575a55a3ab6",
+			"revisionTime": "2017-12-11T20:45:21Z"
+		},
+		{
+			"checksumSHA1": "Iv1YK4j9U0IgQl3/nu3FRjupk4I=",
+			"path": "golang.org/x/net/http2",
+			"revision": "d866cfc389cec985d6fda2859936a575a55a3ab6",
+			"revisionTime": "2017-12-11T20:45:21Z"
+		},
+		{
+			"checksumSHA1": "ezWhc7n/FtqkLDQKeU2JbW+80tE=",
+			"path": "golang.org/x/net/http2/hpack",
+			"revision": "d866cfc389cec985d6fda2859936a575a55a3ab6",
+			"revisionTime": "2017-12-11T20:45:21Z"
+		},
+		{
+			"checksumSHA1": "RcrB7tgYS/GMW4QrwVdMOTNqIU8=",
+			"path": "golang.org/x/net/idna",
+			"revision": "d866cfc389cec985d6fda2859936a575a55a3ab6",
+			"revisionTime": "2017-12-11T20:45:21Z"
+		},
+		{
+			"checksumSHA1": "UxahDzW2v4mf/+aFxruuupaoIwo=",
+			"path": "golang.org/x/net/internal/timeseries",
+			"revision": "d866cfc389cec985d6fda2859936a575a55a3ab6",
+			"revisionTime": "2017-12-11T20:45:21Z"
+		},
+		{
+			"checksumSHA1": "3xyuaSNmClqG4YWC7g0isQIbUTc=",
+			"path": "golang.org/x/net/lex/httplex",
+			"revision": "d866cfc389cec985d6fda2859936a575a55a3ab6",
+			"revisionTime": "2017-12-11T20:45:21Z"
+		},
+		{
+			"checksumSHA1": "u/r66lwYfgg682u5hZG7/E7+VCY=",
+			"path": "golang.org/x/net/trace",
+			"revision": "d866cfc389cec985d6fda2859936a575a55a3ab6",
+			"revisionTime": "2017-12-11T20:45:21Z"
+		},
+		{
+			"checksumSHA1": "LGrodHuObKohCrLBDzLKIpEZsPs=",
+			"path": "golang.org/x/sys/unix",
+			"revision": "83801418e1b59fb1880e363299581ee543af32ca",
+			"revisionTime": "2017-12-22T10:59:23Z"
+		},
+		{
+			"checksumSHA1": "du9BFcn4Qlm/4H3jlRBGGH43aQI=",
+			"path": "golang.org/x/sys/windows",
+			"revision": "83801418e1b59fb1880e363299581ee543af32ca",
+			"revisionTime": "2017-12-22T10:59:23Z"
+		},
+		{
+			"checksumSHA1": "CbpjEkkOeh0fdM/V8xKDdI0AA88=",
+			"path": "golang.org/x/text/secure/bidirule",
+			"revision": "eb22672bea55af56d225d4e35405f4d2e9f062a0",
+			"revisionTime": "2017-12-13T18:21:11Z"
+		},
+		{
+			"checksumSHA1": "ziMb9+ANGRJSSIuxYdRbA+cDRBQ=",
+			"path": "golang.org/x/text/transform",
+			"revision": "eb22672bea55af56d225d4e35405f4d2e9f062a0",
+			"revisionTime": "2017-12-13T18:21:11Z"
+		},
+		{
+			"checksumSHA1": "1oQpUH9BjCWlqFPDahRH+UMlYy4=",
+			"path": "golang.org/x/text/unicode/bidi",
+			"revision": "eb22672bea55af56d225d4e35405f4d2e9f062a0",
+			"revisionTime": "2017-12-13T18:21:11Z"
+		},
+		{
+			"checksumSHA1": "lN2xlA6Utu7tXy2iUoMF2+y9EUE=",
+			"path": "golang.org/x/text/unicode/norm",
+			"revision": "eb22672bea55af56d225d4e35405f4d2e9f062a0",
+			"revisionTime": "2017-12-13T18:21:11Z"
+		},
+		{
+			"checksumSHA1": "Tc3BU26zThLzcyqbVtiSEp7EpU8=",
+			"path": "google.golang.org/genproto/googleapis/rpc/status",
+			"revision": "a8101f21cf983e773d0c1133ebc5424792003214",
+			"revisionTime": "2017-12-12T23:19:43Z"
+		},
+		{
+			"checksumSHA1": "B8z2ZNyNCCG5v2Z1fgHqhFhyRnw=",
+			"path": "google.golang.org/grpc",
+			"revision": "5ff10c3b65ff3ee1c4d6925b263d6f5cdda0b9e7",
+			"revisionTime": "2017-12-14T23:42:58Z"
+		},
+		{
+			"checksumSHA1": "qkqcMp2ECAtqJDCO13G+qe6ihTc=",
+			"path": "google.golang.org/grpc/balancer",
+			"revision": "5ff10c3b65ff3ee1c4d6925b263d6f5cdda0b9e7",
+			"revisionTime": "2017-12-14T23:42:58Z"
+		},
+		{
+			"checksumSHA1": "CPWX/IgaQSR3+78j4sPrvHNkW+U=",
+			"path": "google.golang.org/grpc/balancer/base",
+			"revision": "5ff10c3b65ff3ee1c4d6925b263d6f5cdda0b9e7",
+			"revisionTime": "2017-12-14T23:42:58Z"
+		},
+		{
+			"checksumSHA1": "dgsesZr1kWAbuOMpgf/5bJrZan8=",
+			"path": "google.golang.org/grpc/balancer/roundrobin",
+			"revision": "5ff10c3b65ff3ee1c4d6925b263d6f5cdda0b9e7",
+			"revisionTime": "2017-12-14T23:42:58Z"
+		},
+		{
+			"checksumSHA1": "bfmh2m3qW8bb6qpfS/D4Wcl4hZE=",
+			"path": "google.golang.org/grpc/codes",
+			"revision": "5ff10c3b65ff3ee1c4d6925b263d6f5cdda0b9e7",
+			"revisionTime": "2017-12-14T23:42:58Z"
+		},
+		{
+			"checksumSHA1": "XH2WYcDNwVO47zYShREJjcYXm0Y=",
+			"path": "google.golang.org/grpc/connectivity",
+			"revision": "5ff10c3b65ff3ee1c4d6925b263d6f5cdda0b9e7",
+			"revisionTime": "2017-12-14T23:42:58Z"
+		},
+		{
+			"checksumSHA1": "4DnDX81AOSyVP3UJ5tQmlNcG1MI=",
+			"path": "google.golang.org/grpc/credentials",
+			"revision": "5ff10c3b65ff3ee1c4d6925b263d6f5cdda0b9e7",
+			"revisionTime": "2017-12-14T23:42:58Z"
+		},
+		{
+			"checksumSHA1": "9DImIDqmAMPO24loHJ77UVJTDxQ=",
+			"path": "google.golang.org/grpc/encoding",
+			"revision": "5ff10c3b65ff3ee1c4d6925b263d6f5cdda0b9e7",
+			"revisionTime": "2017-12-14T23:42:58Z"
+		},
+		{
+			"checksumSHA1": "H7SuPUqbPcdbNqgl+k3ohuwMAwE=",
+			"path": "google.golang.org/grpc/grpclb/grpc_lb_v1/messages",
+			"revision": "5ff10c3b65ff3ee1c4d6925b263d6f5cdda0b9e7",
+			"revisionTime": "2017-12-14T23:42:58Z"
+		},
+		{
+			"checksumSHA1": "ntHev01vgZgeIh5VFRmbLx/BSTo=",
+			"path": "google.golang.org/grpc/grpclog",
+			"revision": "5ff10c3b65ff3ee1c4d6925b263d6f5cdda0b9e7",
+			"revisionTime": "2017-12-14T23:42:58Z"
+		},
+		{
+			"checksumSHA1": "Qvf3zdmRCSsiM/VoBv0qB/naHtU=",
+			"path": "google.golang.org/grpc/internal",
+			"revision": "5ff10c3b65ff3ee1c4d6925b263d6f5cdda0b9e7",
+			"revisionTime": "2017-12-14T23:42:58Z"
+		},
+		{
+			"checksumSHA1": "hcuHgKp8W0wIzoCnNfKI8NUss5o=",
+			"path": "google.golang.org/grpc/keepalive",
+			"revision": "5ff10c3b65ff3ee1c4d6925b263d6f5cdda0b9e7",
+			"revisionTime": "2017-12-14T23:42:58Z"
+		},
+		{
+			"checksumSHA1": "KeUmTZV+2X46C49cKyjp+xM7fvw=",
+			"path": "google.golang.org/grpc/metadata",
+			"revision": "5ff10c3b65ff3ee1c4d6925b263d6f5cdda0b9e7",
+			"revisionTime": "2017-12-14T23:42:58Z"
+		},
+		{
+			"checksumSHA1": "5dwF592DPvhF2Wcex3m7iV6aGRQ=",
+			"path": "google.golang.org/grpc/naming",
+			"revision": "5ff10c3b65ff3ee1c4d6925b263d6f5cdda0b9e7",
+			"revisionTime": "2017-12-14T23:42:58Z"
+		},
+		{
+			"checksumSHA1": "n5EgDdBqFMa2KQFhtl+FF/4gIFo=",
+			"path": "google.golang.org/grpc/peer",
+			"revision": "5ff10c3b65ff3ee1c4d6925b263d6f5cdda0b9e7",
+			"revisionTime": "2017-12-14T23:42:58Z"
+		},
+		{
+			"checksumSHA1": "y8Ta+ctMP9CUTiPyPyxiD154d8w=",
+			"path": "google.golang.org/grpc/resolver",
+			"revision": "5ff10c3b65ff3ee1c4d6925b263d6f5cdda0b9e7",
+			"revisionTime": "2017-12-14T23:42:58Z"
+		},
+		{
+			"checksumSHA1": "WpWF+bDzObsHf+bjoGpb/abeFxo=",
+			"path": "google.golang.org/grpc/resolver/dns",
+			"revision": "5ff10c3b65ff3ee1c4d6925b263d6f5cdda0b9e7",
+			"revisionTime": "2017-12-14T23:42:58Z"
+		},
+		{
+			"checksumSHA1": "+JzDc+wsEWeYhqsKV4AzAK14SZg=",
+			"path": "google.golang.org/grpc/resolver/manual",
+			"revision": "5ff10c3b65ff3ee1c4d6925b263d6f5cdda0b9e7",
+			"revisionTime": "2017-12-14T23:42:58Z"
+		},
+		{
+			"checksumSHA1": "zs9M4xE8Lyg4wvuYvR00XoBxmuw=",
+			"path": "google.golang.org/grpc/resolver/passthrough",
+			"revision": "5ff10c3b65ff3ee1c4d6925b263d6f5cdda0b9e7",
+			"revisionTime": "2017-12-14T23:42:58Z"
+		},
+		{
+			"checksumSHA1": "G9lgXNi7qClo5sM2s6TbTHLFR3g=",
+			"path": "google.golang.org/grpc/stats",
+			"revision": "5ff10c3b65ff3ee1c4d6925b263d6f5cdda0b9e7",
+			"revisionTime": "2017-12-14T23:42:58Z"
+		},
+		{
+			"checksumSHA1": "3Dwz4RLstDHMPyDA7BUsYe+JP4w=",
+			"path": "google.golang.org/grpc/status",
+			"revision": "5ff10c3b65ff3ee1c4d6925b263d6f5cdda0b9e7",
+			"revisionTime": "2017-12-14T23:42:58Z"
+		},
+		{
+			"checksumSHA1": "qvArRhlrww5WvRmbyMF2mUfbJew=",
+			"path": "google.golang.org/grpc/tap",
+			"revision": "5ff10c3b65ff3ee1c4d6925b263d6f5cdda0b9e7",
+			"revisionTime": "2017-12-14T23:42:58Z"
+		},
+		{
+			"checksumSHA1": "GWzwAfRSNxYg/kpC2msg5Vt2O4w=",
+			"path": "google.golang.org/grpc/transport",
+			"revision": "5ff10c3b65ff3ee1c4d6925b263d6f5cdda0b9e7",
+			"revisionTime": "2017-12-14T23:42:58Z"
+		}
+	],
+	"rootPath": "github.com/namely/mjolnir"
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -65,10 +65,10 @@
 			"revisionTime": "2017-08-14T20:04:35Z"
 		},
 		{
-			"checksumSHA1": "zmC8/3V4ls53DJlNTKDZwPSC/dA=",
+			"checksumSHA1": "HU1Eoct2jP2YjhvfJGkogXfYFfI=",
 			"path": "github.com/satori/go.uuid",
-			"revision": "5bf94b69c6b68ee1b541973bb8e1144db23a194b",
-			"revisionTime": "2017-03-21T23:07:31Z"
+			"revision": "0ef6afb2f6cdd6cdaeee3885a95099c63f18fc8c",
+			"revisionTime": "2018-01-03T16:02:28Z"
 		},
 		{
 			"checksumSHA1": "ySaT8G3I3y4MmnoXOYAAX0rC+p8=",


### PR DESCRIPTION
This doubles logs for all grpc endpoints when its really not useful.