### PR TITLE
[PG-3] Add Codacy badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
  
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/30f14d8bd9864619bf404699d92682f3)](https://app.codacy.com/gh/namely/mjolnir/dashboard)
 [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/30f14d8bd9864619bf404699d92682f3)](https://app.codacy.com/gh/namely/mjolnir/dashboard)
-
 [![Build Status](https://travis-ci.org/namely/mjolnir.svg?branch=master)](https://travis-ci.org/namely/mjolnir)
 [![Go Report Card](https://goreportcard.com/badge/namely/mjolnir)](https://goreportcard.com/report/namely/mjolnir)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Mjolnir
+ 
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/30f14d8bd9864619bf404699d92682f3)](https://app.codacy.com/gh/namely/mjolnir/dashboard)
+[![Codacy Badge](https://app.codacy.com/project/badge/Coverage/30f14d8bd9864619bf404699d92682f3)](https://app.codacy.com/gh/namely/mjolnir/dashboard)
 
 [![Build Status](https://travis-ci.org/namely/mjolnir.svg?branch=master)](https://travis-ci.org/namely/mjolnir)
 [![Go Report Card](https://goreportcard.com/badge/namely/mjolnir)](https://goreportcard.com/report/namely/mjolnir)


### PR DESCRIPTION

# What does this do?

This PR adds the Codacy badges to the README.md

# Why are we doing this?

The Codacy badges provide an easy at-a-glance view of the code quality and coverage for the repository and increase awareness of quality goals.

Please drop in on the #codacy-discussion channel in Slack if you have any questions.